### PR TITLE
enable nav-bar components

### DIFF
--- a/antora-ui/src/partials/header-content.hbs
+++ b/antora-ui/src/partials/header-content.hbs
@@ -21,6 +21,16 @@
     </div>
     <div id="topbar-nav" class="navbar-menu">
       <div class="navbar-end">
+        <div class="navbar-item has-dropdown is-hoverable">
+          <a class="navbar-link" href="#">{{page.component.title}}</a>
+          <div class="navbar-dropdown">
+            {{#each site.components}}
+              {{#if (ne this @root.page.component)}}
+                <a class="navbar-item" href="{{{relativize ./url}}}">{{{./title}}}</a>
+              {{/if}}
+            {{/each}}
+          </div>
+        </div>
         <!--
         <a class="navbar-item" href="#">Home</a>
         <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
This pull request adds functionality to the navigation bar by implementing a dropdown menu with links to the available components.

It addresses a comment by Andrey that seemed reasonable:

> IMO, this style of navigation is too obscure. I would have never thought to click on "User Guide" in the bottom corner of the screen to switch to other documents. The navigation line at the top is useless because "home" leads to "User Guide" and not a landing page with contents.
