### PR TITLE
Version Control section populated

### DIFF
--- a/.github/ISSUE_TEMPLATE/peters-template.md
+++ b/.github/ISSUE_TEMPLATE/peters-template.md
@@ -1,0 +1,11 @@
+---
+name: Peters template
+about: No known purpose
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Title
+stuff

--- a/.github/ISSUE_TEMPLATE/submit-a-correction-or-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/submit-a-correction-or-bug-report.md
@@ -2,8 +2,8 @@
 name: Submit a Correction or Bug report
 about: This is for typos, grammar, formatting, UI, HTML, or CSS style problems.
 title: ''
-labels: Bug
-assignees: vinniefalco
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/suggest-a-topic--enhancement--or-information.md
+++ b/.github/ISSUE_TEMPLATE/suggest-a-topic--enhancement--or-information.md
@@ -3,7 +3,7 @@ name: Suggest a Topic, Enhancement, or Information
 about: This is for requesting new topics, enhancements to existing exposition, or
   for providing additional information useful for improving the documentation.
 title: ''
-labels: Info
+labels: ''
 assignees: ''
 
 ---

--- a/contributor-guide/modules/ROOT/nav.adoc
+++ b/contributor-guide/modules/ROOT/nav.adoc
@@ -16,6 +16,14 @@
 ** xref:design-guide/dependencies.adoc[]
 ** xref:design-guide/borland.adoc[]
 
+* Development
+** xref:version-control.adoc[]
+** xref:best-practices.adoc[]
+
+* Build Systems
+** xref:build-systems/cmake.adoc[]
+** xref:build-systems/b2.adoc[]
+
 * Testing
 ** xref:testing/intro.adoc[]
 ** xref:testing/boost-test-matrix.adoc[]
@@ -37,11 +45,6 @@
 *** xref:docs/templates/07-bibliography-template.adoc[]
 *** xref:docs/templates/08-acknowledgements-template.adoc[]
 
-* Build Systems
-** xref:build-systems/cmake.adoc[]
-** xref:build-systems/b2.adoc[]
-
 * Releases
-** xref:version-control.adoc[]
 ** xref:release-process.adoc[]
 ** xref:release-notes.adoc[]

--- a/contributor-guide/modules/ROOT/pages/best-practices.adoc
+++ b/contributor-guide/modules/ROOT/pages/best-practices.adoc
@@ -1,0 +1,4 @@
+= Best Practices
+:navtitle: Best Practices
+
+*Content under construction*

--- a/contributor-guide/modules/ROOT/pages/getting-involved.adoc
+++ b/contributor-guide/modules/ROOT/pages/getting-involved.adoc
@@ -33,6 +33,7 @@ After clicking *New Issue*, you will see a list of issue templates, such as *Sub
 
 Whichever list you add your issue to, the issue will be addressed in due course. Providing full details, and examples and screenshots where appropriate, should give you the quicker response.
 
+[#contribute]
 == Contribute to an Existing Library
 
 Rather than report an issue, or suggested improvement, and wait for another developer to address it, you can make the code changes yourself (after verifying with the library admins that they are open to updates). To be successful you will need to be familiar with GitHub, and obviously a competent pass:[C++] developer. After finding the issue, you will need to go to the GitHub repository for that library, and create a fork and clone the library.

--- a/contributor-guide/modules/ROOT/pages/testing/continuous-integration.adoc
+++ b/contributor-guide/modules/ROOT/pages/testing/continuous-integration.adoc
@@ -1,3 +1,149 @@
 = Continuous Integration
 
-*Content under construction.*
+The Boost project uses Continuous Integration (CI) to ensure the quality and integrity of its code. CI is the practice of merging all developers' working copies to a shared mainline several times a day. The main aim is to prevent integration problems, which are detected and can be fixed as early as possible.
+
+Boost uses several CI services for testing on different platforms and compilers. Many libraries use two or three of the systems described here, as does the https://github.com/boostorg/boost/tree/master[Super-project] itself.
+
+Note:: It is a requirement for a new library submission to Boost to include an appropriate CI system. Refer to the examples for each CI system to better understand what is involved.
+
+== GitHub Actions
+
+Boost has been incorporating GitHub Actions into its testing workflows. This is a Continuous Integration/Continuous Deployment (CI/CD) system platform provided directly by GitHub. It can run tests on a variety of platforms and configurations. Here's a basic outline of how GitHub Actions works for Boost:
+
+. GitHub Actions use YAML files stored in a directory called `.github/workflows/` at the root of the repository to define the build environment and steps. For instance, a workflow file might specify which operating systems and compilers to use, any dependencies to install, and the commands to run for building and testing the code.
+
+. When changes are pushed to the repository, or at scheduled intervals, GitHub Actions automatically initiates the actions defined in the workflow file. This might include building the project and running the test suite.
+
+. After the workflow runs, GitHub Actions reports the result. If any step in the workflow fails, the failure is reported, which helps developers to quickly identify and address issues. The status of each workflow run is displayed on the GitHub interface, allowing anyone to quickly check the status of the project.
+
+Boost also uses GitHub Actions support for matrix builds (allowing Boost to run the same build steps on multiple combinations of operating systems, compilers, etc.), caching of dependencies to speed up builds, and the ability to create custom actions.
+
+=== Example GitHub Workflows
+
+Refer to:
+
+* https://github.com/boostorg/boost/blob/master/.github/workflows/ci.yml[Super-project ci.yml]
+* https://github.com/boostorg/boost/blob/master/.github/workflows/release.yml[Super-project release.yml]
+* https://github.com/boostorg/align/blob/5ad7df63cd792fbdb801d600b93cad1a432f0151/.github/workflows/ci.yml[Align library ci.yml]
+* https://github.com/boostorg/coroutine2/blob/d7e1c1c4abcf8c1e90097279e485edea0b253a80/.github/workflows/ci.yml[Coroutine2 ci.yml]
+* https://github.com/boostorg/mp11/blob/ef7608b463298b881bc82eae4f45a4385ed74fca/.github/workflows/ci.yml[Mp11 library ci.yml]
+
+=== GitHub Actions Reference
+
+* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions[Workflow syntax for GitHub Actions]
+
+== Drone
+
+Drone is an open-source CI system built on container technology. Each step in a Drone build usually runs in its own Docker container, allowing it to use any language, tool, or service that can run inside a Docker container. This offers excellent environment consistency and isolation between steps. You can run your Drone pipelines locally on your machine for testing purposes before pushing changes to your repository.
+
+. Drone uses a file named `.drone.jsonnet` or `.drone.star`, and a `.drone` folder, at the root of the repository to define the build pipeline, including the environment, build steps, and notification settings. The environment is typically a Docker container, allowing for a high degree of flexibility and customization.
+
+. When changes are pushed to the repository, Drone automatically runs the build pipeline defined in the `.drone` file. This  involves building the software and running a suite of tests.
+
+. After the pipeline finishes, Drone reports the results. If any step fails, developers can be notified immediately, helping to catch and fix issues early. The status of each pipeline run can also be seen on the Drone dashboard and optionally on the GitHub interface.
+
+Drone also includes support for matrix builds, secrets management (for handling sensitive data), and plugins (for extending functionality).
+
+=== Example .drone Files
+
+Refer to:
+
+* https://github.com/boostorg/smart_ptr/blob/13be03abf880cdb616d0597c38880f53f1b415b8/.drone.jsonnet[Smart Pointer library .drone.jsonnet]
+
+* https://github.com/boostorg/type_traits/blob/89f5011b4a79d91e42735670e39f72cb25c86c72/.drone.star[Type Traits library .drone.star]
+
+* https://github.com/boostorg/variant2/blob/e2546b70ca04d4263f7a5917815506e488b6920f/.drone.jsonnet[Variant2 library .drone.jsonnet]
+
+* https://github.com/boostorg/unordered/blob/9a7d1d336aaa73ad8e5f7c07bdb81b2e793f8d93/.drone.jsonnet[Unordered library .drone.jsonnet]
+
+* https://github.com/boostorg/yap/blob/ae49bf2744586e6bd6c0cedff4500a58a4386860/.drone.star[Yap library .drone.star]
+
+=== Drone Reference
+
+* https://docs.drone.io/[Drone Documentation]
+
+
+== Travis CI
+
+Travis CI is used for testing on Linux and macOS environments. It is a hosted, distributed continuous integration service used to build and test software projects hosted at GitHub. Here's the overall process:
+
+. Travis CI uses a file named `.travis.yml` in the root of the repository to define the build environment and the build steps. This file lists the operating systems and compilers to use, any dependencies to install, and the commands to run for building and testing the code.
+
+. Whenever changes are pushed to the repository on GitHub, Travis CI automatically initiates a build and runs the tests according to the instructions in `.travis.yml`. Boost libraries usually have extensive test suites, and Travis CI helps ensure that changes do not break existing functionality.
+
+. After each build, Travis CI reports the results. If the build or any tests fail, it can notify the developers so that they can fix the issue. On GitHub, the status of the latest build is shown next to each commit, so anyone can quickly see whether the current version of the code is passing all tests.
+
+Boost also uses Travis CI's features for more complex workflows, using the matrix feature to test code with multiple versions of compilers or dependencies, and uses stages to structure their build pipeline into phases like *build*, *test*, and *deploy*.
+
+=== Example .travis.yml Files
+
+Refer to:
+
+* https://github.com/boostorg/boost/blob/master/.travis.yml[Super-project .travis.yml]
+* https://github.com/boostorg/coroutine2/blob/d7e1c1c4abcf8c1e90097279e485edea0b253a80/.travis.yml[Coroutine2 library .travis.yml]
+* https://github.com/boostorg/fiber/blob/2cb72f5dcefdeffbb36636234e6ccb36282f8ae3/.travis.yml[Fiber library .travis.yml]
+* https://github.com/boostorg/iostreams/blob/5fe4de84f863964f7573be1146f524886146a5d3/.travis.yml[IOStreams library .travis.yml]
+
+=== Travis CI Reference
+
+* https://docs.travis-ci.com/user/for-beginners/[Travis CI Core Concepts]
+
+== AppVeyor
+
+AppVeyor is used for testing on Windows. It is a continuous integration service which can be configured to build projects for various systems, including MSVC, MinGW, and Cygwin. The overall process is:
+
+. AppVeyor uses a file named `appveyor.yml` in the root of the repository to define the build environment and the steps for building and testing. This file describes which Windows images to use, any dependencies that need to be installed, and the commands to run for building and testing the code.
+
+. When changes are pushed to the GitHub repository, AppVeyor automatically initiates a build and runs the tests according to the instructions in `appveyor.yml`. The goal of this is to catch and fix any failures or issues that occur in the Windows environment.
+
+. After each build, AppVeyor reports the result. If the build or any tests fail, it notifies the developers, allowing them to address the issues. The status of the latest build can also be seen on GitHub, providing an at-a-glance view of the code's health.
+
+AppVeyor also supports parallel testing, a build cache to speed up builds, and the ability to deploy built artifacts.
+
+=== Example appveyor.yml Files
+
+Refer to:
+
+* https://github.com/boostorg/boost/blob/master/appveyor.yml[Super-project appveyor.yml]
+* https://github.com/boostorg/beast/blob/c316c6bd3571991aeac65f0fc35fca9067bc7906/appveyor.yml[Beast library appveyor.yml]
+* https://github.com/boostorg/iostreams/blob/5fe4de84f863964f7573be1146f524886146a5d3/appveyor.yml[IOStreams library appveyor.yml]
+* https://github.com/boostorg/mp11/blob/ef7608b463298b881bc82eae4f45a4385ed74fca/appveyor.yml[Mp11 library appveyor.yml]
+
+=== Appveyor Reference
+
+* https://www.appveyor.com/docs/[Welcome to Appveyor]
+
+
+== CircleCI
+
+CircleCI is a CI/CD platform that supports a wide range of languages, tools, and services, making it flexible for different testing requirements. It is less commonly used than <<Travis CI>> or <<AppVeyor>>, but is used by the Super-project and a few libraries.
+
+. CircleCI uses a file named `config.yml` stored in a directory called `.circleci` at the root of the repository. This file defines the build environment and steps, such as which Docker images to use, dependencies to install, and the commands for building and testing.
+
+. Upon changes being pushed to the repository or on a schedule, CircleCI automatically executes the instructions in the `config.yml` file. This usually includes building the project and running the test suite.
+
+. After the workflow completes, CircleCI reports the results. If any part of the workflow fails, developers are notified, which allows them to address the issues swiftly. The status of the workflow run is visible on the GitHub interface, providing at-a-glance insights into the project's health.
+
+CircleCI also supports parallel testing, caching of dependencies, and matrix builds.
+
+=== Example config.yml Files
+
+Refer to:
+
+* https://github.com/boostorg/boost/blob/master/.circleci/config.yml[Super-project config.yml]
+* https://github.com/boostorg/beast/blob/c316c6bd3571991aeac65f0fc35fca9067bc7906/.circleci/config.yml[Beast library config.yml]
+* https://github.com/boostorg/geometry/blob/2ec9d65d1294edb97157b564726fdf56b6ac562f/.circleci/config.yml[Geometry library config.yml]
+* https://github.com/boostorg/multiprecision/blob/380aae3c28c646ea2ca1b42156d83732295082d7/.circleci/config.yml[Multiprecision library config.yml]
+
+=== CircleCI Reference
+
+* https://circleci.com/developer[Welcome to CircleCI]
+
+
+== Other CI Systems
+
+Other CI systems can be implemented by library developers. For example, https://learn.microsoft.com/en-us/azure/devops/pipelines/?view=azure-devops[Azure Pipelines] is a cloud service provided by Microsoft to automatically build, test, and deploy applications.
+
+== See Also
+
+* xref:version-control.adoc[]

--- a/contributor-guide/modules/ROOT/pages/version-control.adoc
+++ b/contributor-guide/modules/ROOT/pages/version-control.adoc
@@ -1,4 +1,145 @@
-= Version Control (Git)
+= Version Control
 :navtitle: Version Control
 
-*Content under construction.*
+Boost uses the Git version control system for its development. This allows multiple contributors to work on the libraries concurrently, while keeping track of the changes that each person makes. Git is a distributed version control system, which means each contributor has their own local copy of the entire project, including its history.
+
+== Library Repositories
+
+The Boost libraries are modular, and each library has its own separate repository.  This makes it easier to work with the entire collection of Boost libraries.
+
+The official Boost repositories are hosted in GitHub under the https://github.com/boostorg/[] account. Each library has its own repository under this organization. For example, https://github.com/boostorg/json for boost:json[], or https://github.com/boostorg/date_time/ for boost:date_time[].
+
+As with any Git-based project, you can clone the repositories, make changes, commit those changes to your local repository, and push your changes back to the server. If you want to contribute changes to the official Boost libraries, refer to xref:getting-involved.adoc#contribute[Contribute to an Existing Library].
+
+== The Super-project Repository
+
+The Boost https://github.com/boostorg/boost[*Super-project*] repository includes all the libraries as submodules.
+
+In addition to the libraries, you'll find many other repositories under `boostorg` that handle other tasks, for example:
+
+* https://github.com/boostorg/boost/tree/master/tools[boost/tools] includes B2 sources in https://github.com/boostorg/build/tree/bc381862203c9de80d552d93539a1168664e0243[build], and https://github.com/boostorg/cmake[CMake support]
+* https://github.com/boostorg/release-tools[Release tools]
+
+The Super-project has both *master* and *develop* branches, which operate somewhat differently than for individual libraries. 
+
+New features are added and bugs are fixed in library *develop* branches. When the *develop* branch passes its' merging criteria (xref:testing/continuous-integration.adoc[], projects are built correctly, other test processes run without errors, etc.), it is merged with the library *master* branch. 
+
+For the Super-project, the *develop* and *master* branches are independent. Both branches track the latest changes in the corresponding library branch, for all libraries. The Super-project branches are never merged, as this strategy prevents merging. In other words, the Super-project *master* branch is created from the library *master* branches, not from the Super-project *develop* branch (which is primarily used for testing).
+
+When there is a public release of Boost, it is built from the *master* branch after that branch has been closed to updates (refer to the xref:release-process.adoc[]).
+
+=== Working with the Super-project
+
+Usually, a submodule in the Super-project will be created for a library developer by a staff member of Boost.
+
+* Recall that, in Git, when a submodule is added to a project, the submodule references a particular commit. This means that, when developers update their sub-projects, the Super-project _doesn't_ get immediately updated. For this reason, there is a commit bot that runs nightly and updates the commit to which each submodule references in the Super-project. This happens for both the *develop* and *master* branches. 
+
+* As you update your library, and the Super-project *develop* branch is updated by the commit bot, you may affect other developers. For example, if a mistake is made to the MySQL library *develop* branch, then it will affect the CMake module, because this module runs tests to verify that you can use MySQL via CMake.
+
+* As part of Boost testing, xref:testing/continuous-integration.adoc[] (CI) usually clones the Super-project and any required submodules. 
+
+** When testing any branch that is _not_ *master*, the *develop* branch of the Super-project is cloned. 
+** When you're testing *master* (which could be for a release), the *master* branch of the Super-project is cloned. 
++
+While this cloning process is not a _requirement_, most libraries follow it.
+
+If you need to look at the code for the 1.82.0 release, navigate to the relevant repo, and enter:
+
+[source,text]
+----
+git checkout boost-1.82.0 
+----
+
+NOTE:: Developers don't directly create Tags under repositories, when working with Boost. Tags are created by the release scripts, both in the Super-project and the individual repos, so do not add any of your own. This differs from the usual workflow in other non-Boost projects.
++
+
+
+== Breaking Changes
+
+Boost maintains its release versions with https://github.com/boostorg/boost/tags[Tags], where the tag is always the `boost-` prefix followed by a `major.minor.patch` number string that matches the https://semver.org/[Semantic Versioning] string format. The string format is useful because it's something many tools understand, and for most users who just want to find a certain Boost version, that's enough information. However, there is a unique Boost interpretation of the string. 
+
+=== Major Version
+
+Boost has not to date increased its' _major_ version number. This is reserved for when something "big" happens, not for feature improvements nor API breaks.
+
+=== Minor Version
+
+While library maintainers try hard not to break anything, the _minor_ version is increased when:
+
+    * Three months have passed since the last release.
+    * New features have been added because they always are.
+    * A few things might have been broken. Details on new features and discontinued features have to be consulted in the individual libraries' xref:release-notes.adoc[Release Notes]. 
+
+=== Patch Version
+
+The _patch_ number is rarely used, but will be incremented from zero if there is a need for a quick update following a scheduled release. For example, `boost-1.65.1` followed less than one month after `boost-1.65.0`. 
+
+=== Planning for Breaking Changes
+
+One thing library maintainers do to mitigate problems is announce their intention to break something two releases (or six months) in advance. Some maintainers keep a parallel versioning system for their library, for example: 
+
+* https://github.com/boostorg/filesystem/blob/7bb038fcb887442e05619db6f48efc9df71c1fc3/include/boost/filesystem/config.hpp#L23-L25[File system config]
+* https://github.com/boostorg/beast/blob/af5240f6f1a15ba328c763f2c505a60a3cbcb555/CMakeLists.txt#L86[Beast CMakeLists]
+
+Ultimately though, even after checking both a library readme file, and for library announcements, some testing may be necessary to be certain of whether a breaking change occurred, or not.
+
+## Bugs, Issues, Feature Requests and Discussions
+
+The repositories use the built-in GitHub issue tracker. With Boost, users are encouraged to use the issue tracker for discussions and feature requests, as well as to report bugs and other issues.
+
+Consider creating custom templates for your library. The goal of these templates is to ensure that contributors provide enough context and information that you, and the other library authors and maintainers, can understand and reproduce the issue, or fully understand what is being discussed.
+
+### How to Create an Issue Template
+
+Creating an issue template in GitHub can help guide contributors to provide the necessary information when they create new issues with your library.
+
+Here are the steps to create an issue template:
+
+. Navigate to the main page of your repository.
+
+. In the menu bar (`Code`, `Pull Requests`, etc.), click on `Settings`.
+
+. In the `Features` section, ensure that the `Issues` checkbox is selected.
+
+. In the section `Get organized with issue templates`, click on `Set up templates`.
+
+. Click on the down arrow of `Add template: select`, then select `Custom template`. 
+
+. Click on `Preview and edit` for your custom template. Then select the pen icon to bring up the template fields.
+
+. Give your template a descriptive name, perhaps the name of your library followed by "feature request", "performance issue", "bug report" or "discussion". Remember you can enter as many templates as you think appropriate.
+
+. Give the template a full description in the `About` box.
+
+. Then add the meat of the template to the `Template content`. Consider adding the following, in the form of Markdown syntax and example text, to ask your users to enter:
+
+** Boost version number
+** The OS, compiler, hardware they are using
+** A brief summary of the issue/request/discussion topic
+** In the case of a bug or issue: 
+*** Steps to reproduce the issue
+*** Expected behavior
+*** Actual behavior
+*** Screenshots, error messages, output
+** In the case of a feature request or discussion:
+*** Accurately describe the purpose of the request (the use case, not the implementation)
+*** Describe what they are currently doing to address the issue
+** Any other relevant context or information
+
+. Add the `Optional additional items` if they fit the purpose of the template, and perhaps add yourself as one of the `Assignees`.
+
+. When you're done editing, at the top right of the page, click `Propose changes`.
+
+. Click `Commit changes` and create a Pull Request to update your repo.
+
+Once the template is added, users who create new issues in your repository can choose to use one of your templates.
+
+Note:: Currently, the Boost Super-project does not use the GitHub Discussion feature. If filing an issue does not seem appropriate, users are encouraged to post on the https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers mailing list].
+
+== See Also
+
+For the user's perspective on issues, refer to xref:user-guide:ROOT:reporting-issues.adoc[].
+
+* xref:testing/continuous-integration.adoc[]
+* xref:release-notes.adoc[]
+* xref:release-process.adoc[]

--- a/user-guide/modules/ROOT/pages/reporting-issues.adoc
+++ b/user-guide/modules/ROOT/pages/reporting-issues.adoc
@@ -9,14 +9,48 @@ If you come across a bug, or other issue, with one of the libraries, go through 
 
 . https://github.com/boostorg/boost/issues[Search the issues] on GitHub to make sure we don't already know about the bug. If we do, you can certainly add further information to an existing bug ticket.
 
-. If the bug has not been fixed already, and there is no relevant issue, then https://github.com/boostorg/boost/issues/new[Create a New Issue], either in the repository of the particular library of interest, or in the boost super-project.
+. If the bug has not been fixed already, and there is no relevant issue, then report it.
 
-If possible,
+== Bug and Issue Reporting
 
-[disc]
-* Describe the problem carefully, including steps required to reproduce it by a library maintainers.
+The repositories use the built-in GitHub issue tracker. With Boost, users are encouraged to use the issue tracker for discussions and feature requests, as well as to report bugs and other issues.
 
-* Attach a _minimal_ and _complete_ program that reproduces the problem. Aside from helping the library maintainer fix the problem, you may find the bug in your own code, which can avoid a costly delay waiting for a response.
+To report an issue, locate the *New Issue* button in the repo for the library. For example, https://github.com/boostorg/json/issues for the boost:json[] library.
+
+When reporting a bug or issue, you might be offered a range of templates to choose from to guide your filing. If there is no template to follow, cut-and-paste the following into the text field for the issue, and replace the text in italics with appropriate details.
+
+[source,markdown]
+----
+### Version of Boost
+
+_Enter the Boost version number, such as `1.82.0`._
+
+### Actual and Expected Behavior
+
+_Describe the result you got, and what you consider the result should be._
+
+_Attach a _minimal_ and _complete_ program that reproduces the problem._
+
+_Aside from helping the library maintainer fix the problem, you may find the bug in your own code, which can avoid a costly delay waiting for a response._
+
+### Steps necessary to reproduce the problem
+
+_Describe the problem carefully, including steps required to reproduce it by library maintainers._
+
+_A small compiling program is the best. If your code is public, you can provide a link to the repository._
+
+### All relevant compiler information
+
+_If you are unable to compile include the type and version of compiler you are using as well as all compiler output including the error message, file, and line numbers involved._
+----
+
+The more information you provide the sooner your issue can get resolved.
+
+Note:: Currently, the Boost Super-project does not use the GitHub Discussion feature. If filing an issue does not seem appropriate, post on the https://lists.boost.org/mailman/listinfo.cgi/boost[Boost developers mailing list].
+
+== See Also
+
+For information on issues from the library contributor's perspective, refer to xref:contributor-guide:ROOT:version-control.adoc[].
 
 
 


### PR DESCRIPTION
@anarthal Not sure I have included everything you noted for version control - I could not find any generic method for finding a particular version of a library - release notes or the meta information was not consistent - but perhaps it is not needed if the Boost version is known. Let me know if more content is needed. Do individual contributors need to know more about the tools for the Super-project perhaps?
@alandefreitas  fyi