### PR TITLE
Change centos to RHEL in getting started label

### DIFF
--- a/user-guide/modules/ROOT/pages/getting-started.adoc
+++ b/user-guide/modules/ROOT/pages/getting-started.adoc
@@ -58,7 +58,7 @@ sudo dnf update
 sudo dnf install gcc-c++ python3 bzip2-devel zlib-devel libicu-devel
 ----
 
-For CentOS systems, use the following commands:
+For Redhat-based systems (RHEL, CentOS Stream, etc.), use the following commands:
 
 [source,bash]
 ----


### PR DESCRIPTION
A pedantic change but CentOS is now CentOS stream, and we will certainly have people looking for RHEL instructions.