### PR TITLE
Antora playbooks initially contain no content sources

### DIFF
--- a/history/libs.1.81.0.playbook.yml
+++ b/history/libs.1.81.0.playbook.yml
@@ -3,12 +3,10 @@ site:
   title: Boost Libraries Documentation
   start_page: user-guide::index.adoc
 
-content:
-  sources:
-  - url: https://github.com/cppalliance/user-guide
-    start_path: antora
-  - url: https://github.com/vinniefalco/mp11
-    start_path: antora
+#content:
+#  sources:
+#  - url: https://github.com/vinniefalco/mp11
+#    start_path: antora
 
 ui:
   bundle:

--- a/history/libs.1.82.0.playbook.yml
+++ b/history/libs.1.82.0.playbook.yml
@@ -3,15 +3,12 @@ site:
   title: Boost Libraries Documentation
   start_page: user-guide::index.adoc
 
-content:
-  sources:
-  - url: https://github.com/cppalliance/user-guide
-    start_path: antora
-
-  - url: https://github.com/vinniefalco/mp11
-    start_path: antora
-  - url: https://github.com/vinniefalco/predef
-    start_path: antora
+#content:
+#  sources:
+#  - url: https://github.com/vinniefalco/mp11
+#    start_path: antora
+#  - url: https://github.com/vinniefalco/predef
+#    start_path: antora
 
 ui:
   bundle:

--- a/history/libs.1.83.0.playbook.yml
+++ b/history/libs.1.83.0.playbook.yml
@@ -3,17 +3,14 @@ site:
   title: Boost Libraries Documentation
   start_page: user-guide::index.adoc
 
-content:
-  sources:
-  - url: https://github.com/cppalliance/user-guide
-    start_path: antora
-
-  - url: https://github.com/vinniefalco/mp11
-    start_path: antora
-  - url: https://github.com/vinniefalco/predef
-    start_path: antora
-  - url: https://github.com/vinniefalco/qvm
-    start_path: antora
+#content:
+#  sources:
+#  - url: https://github.com/vinniefalco/mp11
+#    start_path: antora
+#  - url: https://github.com/vinniefalco/predef
+#    start_path: antora
+#  - url: https://github.com/vinniefalco/qvm
+#    start_path: antora
 
 ui:
   bundle:

--- a/libs.playbook.yml
+++ b/libs.playbook.yml
@@ -44,16 +44,17 @@ asciidoc:
     - ./extensions/boost-link-inline-macro.js
     - '@asciidoctor/tabs'
 
-content:
-  sources:
-    - url: https://github.com/vinniefalco/mp11
-      start_path: antora
-    - url: https://github.com/vinniefalco/predef
-      start_path: antora
-    - url: https://github.com/vinniefalco/qvm
-      start_path: antora
-    - url: https://github.com/vinniefalco/unordered
-      start_path: antora
+# Libraries that support Antora should be included here
+#content:
+#  sources:
+#    - url: https://github.com/vinniefalco/mp11
+#      start_path: antora
+#    - url: https://github.com/vinniefalco/predef
+#      start_path: antora
+#    - url: https://github.com/vinniefalco/qvm
+#      start_path: antora
+#    - url: https://github.com/vinniefalco/unordered
+#      start_path: antora
 
 ui:
   bundle:


### PR DESCRIPTION
This PR removes mock content sources from Antora playbooks, as Antora is now integrated into the official boost workflow in release-tools.