### PR TITLE
Run "npm ci"

### DIFF
--- a/.github/actions/antora_publish/action.yml
+++ b/.github/actions/antora_publish/action.yml
@@ -42,12 +42,8 @@ runs:
       shell: bash
       run: |
         if test -f "package.json"; then
-            npm install
+            npm ci
         fi
-
-    - name: Install Antora
-      shell: bash
-      run: npm i antora
 
     - name: Install Antora Extensions
       if: inputs.extensions != ''

--- a/.github/workflows/ui-release.yml
+++ b/.github/workflows/ui-release.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build
       working-directory: antora-ui
       run: |
-        npm install
+        npm ci
         gulp bundle
 
     - name: Bundle

--- a/README.adoc
+++ b/README.adoc
@@ -44,7 +44,7 @@ After cloning the project, you need to https://docs.antora.org/antora/latest/ins
 
 [source,bash]
 ----
-$ npm install
+$ npm ci
 ----
 
 Verify the antora command is now available by running:

--- a/antora-ui/build.sh
+++ b/antora-ui/build.sh
@@ -15,7 +15,7 @@ if [ -z "$gulp_version" ]; then
 fi
 
 if [ ! -d "node_modules" ] || [ "$(find package.json -prune -printf '%T@\n' | cut -d . -f 1)" -gt "$(find node_modules -prune -printf '%T@\n' | cut -d . -f 1)" ]; then
-  npm install
+  npm ci
 fi
 
 gulp bundle

--- a/libdoc.sh
+++ b/libdoc.sh
@@ -63,7 +63,7 @@ else
 fi
 
 if [ ! -d "node_modules" ] || [ "$(find package.json -prune -printf '%T@\n' | cut -d . -f 1)" -gt "$(find node_modules -prune -printf '%T@\n' | cut -d . -f 1)" ]; then
-  npm install
+  npm ci
 fi
 
 # Run antora command

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       },
       "devDependencies": {
         "@antora/cli": "3.1.2",
-        "@antora/site-generator": "3.1.2"
+        "@antora/site-generator": "3.1.2",
+        "antora": "3.1.2"
       }
     },
     "node_modules/@antora/asciidoc-loader": {
@@ -329,6 +330,22 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/antora": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/antora/-/antora-3.1.2.tgz",
+      "integrity": "sha512-v+78jtE1XZ44dm8rYIyWvFzteBw/QEKyD0QJQMk2I7I3F3QPK2cruPXoVVfwq+vfzL9oqv2dqjrf2cTpHjsIpQ==",
+      "dev": true,
+      "dependencies": {
+        "@antora/cli": "3.1.2",
+        "@antora/site-generator": "3.1.2"
+      },
+      "bin": {
+        "antora": "bin/antora"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/append-buffer": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "devDependencies": {
     "@antora/cli": "3.1.2",
-    "@antora/site-generator": "3.1.2"
+    "@antora/site-generator": "3.1.2",
+    "antora": "3.1.2"
   },
   "dependencies": {
     "@antora/lunr-extension": "^1.0.0-alpha.8",

--- a/sitedoc.sh
+++ b/sitedoc.sh
@@ -58,7 +58,7 @@ else
 fi
 
 if [ ! -d "node_modules" ] || [ "$(find package.json -prune -printf '%T@\n' | cut -d . -f 1)" -gt "$(find node_modules -prune -printf '%T@\n' | cut -d . -f 1)" ]; then
-  npm install
+  npm ci
 fi
 
 # TODO: Find a better way of setting these


### PR DESCRIPTION
When calling `npm install` you probably expect the results of `npm ci`. That is, it ought to install the exact package versions from package-lock.json. However `npm install` may update or write to package.json or package-lock.json. `npm install` isn't guaranteed to be consistent. `npm ci` installs what is listed in package-lock.json.

Always specify versions, so instead of

```
npm i antora
```

use

```
npm i antora@3.1.2
```

However in this case I moved antora into package.json (which adds a negligible amount of disk space, almost nothing) and removes the extra `npm i antora` command.    If you don't agree with the change, we can put it back, but at least with a version specifier `@3.1.2`.

Occasionally (every year or two) update npm packages. To do this, remove version constraints from package.json, run "npm update", generate a new package-lock.json, etc., check it in.  