### PR TITLE
Populating the Help page from the FAQ

### DIFF
--- a/site-pages/help.adoc
+++ b/site-pages/help.adoc
@@ -1,5 +1,361 @@
 = Help
 
-This is the help page.
-
 You can submit content for this page here: https://github.com/cppalliance/site-docs.
+
+== Frequently Asked Questions
+
+This section contains answers to the common questions that new developers to Boost often have.
+
+=== Compatibility
+
+. *Can I use Boost with my existing pass:[C++] project?*
+
++
+Yes, Boost is designed to work with your existing pass:[C++] code. You can add Boost libraries to any project that uses a compatible pass:[C++] compiler.
+
+. *Can I use Boost libraries with the new pass:[C++] standards?*
+
++
+Yes, Boost libraries are designed to work with modern pass:[C++] standards including pass:[C++11], pass:[C++14], pass:[C++17], and pass:[C++20].
+
+. *What flavors of Linux are supported by the Boost libraries?*
++
+Boost libraries are generally compatible with most Linux distributions, provided that the distribution has an up-to-date pass:[C++] compiler. This includes:
++
+* Ubuntu
+* Fedora
+* Debian
+* CentOS
+* Red Hat Enterprise Linux
+* Arch Linux
+* openSUSE
+* Slackware
+* Gentoo
+* macOS
+
+. *How can I be sure that a library I want to use is compatible with my OS?*
++
+While Boost strives to ensure compatibility with a wide range of compilers and systems, not every library may work perfectly with every system or compiler due to the inherent complexities of software. The most reliable source of information is the specific Boost library's documentation.
+
+=== Debugging
+
+. *What support does Boost provide for debugging and testing?*
++
+Boost provides boost:test for unit testing, which can be an integral part of the debugging process. It also provides the boost:stacktrace[] library that can be used to produce useful debug information during a crash or from a running application.
+
+. *How do I enable assertions in Boost?*
++
+Boost uses its own set of assertion macros. By default, `BOOST_ASSERT` is enabled, but if it fails, it only calls `abort()`. If you define `BOOST_ENABLE_ASSERT_HANDLER` before including any Boost header, then you need to supply `boost::assertion_failed(msg, code, file, line)` and `boost::assertion_failed_msg(msg, code, file, line)` functions to handle failed assertions.
+
+. *How can I get a stack trace when my program crashes?*
++
+You can use the boost:stacktrace[] library to obtain a stack trace in your application. You can capture and print stack traces in your catch blocks, in signal handlers, or anywhere in your program where you need to trace the execution path.
+
+. *Can I use Boost with a debugger like GDB or Visual Studio?*
++
+Yes, Boost libraries can be used with common debuggers like GDB or Visual Studio. You can set breakpoints in your code, inspect variables, and execute code step by step. Boost doesn't interfere with these debugging tools.
+
+. *Are there any debugging tools specifically provided by Boost?*
++
+Boost doesn't provide a debugger itself. The libraries tend to make heavy use of assertions to catch programming errors, and they often provide clear and detailed error messages when something goes wrong.
+
+. *What are best practices when using Boost Asserts?*
++
+Boost provides the assertion `boost::assert`. Best practices when using this are:
+
++
+[disc]
+* _Use Assertions for Debugging and Development_: Boost assertions should primarily be used during the debugging and development phase of your application. Assertions are designed to catch programming errors, not user errors.
+
+* _Assert Conditions That Should Never Occur_: You should only assert conditions that you believe can never occur during normal operation of your application. If there's a chance that a condition may occur, handle it as an exception or error rather than asserting.
+
+* _Provide Meaningful Assert Messages_: Boost assertions allow you to provide a message alongside your assertion. Use this feature to provide meaningful context about why an assertion failed.
+
+* _Consider Performance Impact_: Boost assertions can slow down your application. In performance-critical code, consider disabling them in the production version of your application.
+
+. *What is the recommended approach to logging, using `boost::log`?*
++
+[disc]
+* _Use Severity Levels_: boost:log[] supports severity levels, which you can use to categorize and filter your log messages. This can help you control the amount of log output and focus on what's important.
+
+* _Provide Context_:boost:log[] allows you to attach arbitrary data to your log messages, such as thread IDs, timestamps, or file and line information. Use this feature to provide context that can help you understand the state of your application when the log message was generated.
+
+* _Use Asynchronous Logging_: If logging performance is a concern, consider using the asynchronous logging feature. This allows your application to continue executing while log messages are processed in a separate thread.
+
+* _Format Your Log Output_: boost:log[] supports customizable log formatting. Use this feature to ensure that your log output is easy to read and contains all the information you need.
+
+* _Handle Log Rotation_: If your application produces a lot of log output, consider setting up log rotation, which is supported. This ensures that your log files don't grow indefinitely.
+
+=== Libraries
+
+. *What are smart pointers in Boost?*
++
+Smart pointers are a feature of pass:[C++] that Boost provides in its boost:smart_ptr[] library. They are objects that manage the lifetime of other objects, automatically deleting the managed object when it is no longer needed. See the <<Smart Pointers>> section.
+
+. *Does Boost provide a testing framework?*
++
+Yes, boost:test[] is the unit testing framework provided by Boost. It includes tools for creating test cases, test suites, and for handling expected and unexpected exceptions. Refer to xref:testing-debugging.adoc[].
+
+. *What is Boost.Asio?*
++
+boost:asio[] is a library that provides support for asynchronous input/output (I/O), a programming concept that allows operations to be executed without blocking the execution of the rest of the program.
+
+. *What is Boost.MP11?*
++
+boost:mp11[] (MetaProgramming Library for pass:[C++]11) is a Boost library designed to bring powerful metaprogramming capabilities to pass:[C++] programs. It includes a variety of templates that can be used to perform compile-time computations and manipulations. Refer to <<Metaprogramming>>.
+
+. *Does Boost provide a library for threading?*
++
+Yes, boost:thread[] provides a pass:[C++] interface for creating and managing threads, as well as primitives for synchronization and inter-thread communication.
+
+. *What is the Boost Spirit library?*
++
+boost:spirit[] is a library for building recursive-descent parsers directly in pass:[C++]. It uses template metaprogramming techniques to generate parsing code at compile time.
+
+. *I like algorithms, can you pique my interest with some Boost libraries that support complex algorithms?* 
++
+Boost libraries offer a wide range of algorithmic and data structure support. Here are five libraries that you might find interesting:
+
++
+* boost:graph[]: This library provides a way to represent and manipulate graphs. It includes algorithms for breadth-first search, depth-first search, Dijkstra's shortest paths, Kruskal's minimum spanning tree, and much more.
+
+* boost:geometry[]: This library includes algorithms and data structures for working with geometric objects. It includes support for spatial indexing, geometric algorithms (like area calculation, distance calculation, intersections, etc.), and data structures to represent points, polygons, and other geometric objects.
+
+* boost:multiprecision[]: If you need to perform computations with large or precise numbers, this library can help. It provides classes for arbitrary precision arithmetic, which can be much larger or more precise than the built-in types.
+
+* boost:compute[]: This library provides a pass:[C++] interface to multi-core CPU and GPGPU computing platforms based on OpenCL. It includes algorithms for sorting, searching, and other operations, as well as containers like vectors and deques.
+
+* boost:spirit[]: If you're interested in parsing or generating text, this library includes powerful tools based on formal grammar rules. It's great for building compilers, interpreters, or other tools that need to understand complex text formats.
+
+. *I am tasked with building a real-time simulation of vehicles in pass:[C++]. What Boost libraries might give me the performance I need for real-time work, and support a simulation?*
++
+Refer to xref:task-simulation.adoc[].
+
+=== Licensing 
+
+. *What is the license for Boost libraries?*
++
+The Boost libraries are licensed under the Boost Software License, a permissive free software license that allows you to use, modify, and distribute the software under minimal restrictions. Refer to xref:bsl.adoc[].
+
+=== Metaprogramming
+
+. *What is metaprogramming in the context of Boost pass:[C++]?*
++
+Metaprogramming is a technique of programming that involves generating and manipulating programs. In the context of Boost and pass:[C++], metaprogramming often refers to template metaprogramming, which uses templates to perform computations at compile-time.
+
+. *What is Boost.MP11?*
++
+boost:mp11[] is a Boost library designed for metaprogramming. It provides a set of templates and types for compile-time computations and manipulations, effectively extending the pass:[C++] template mechanism.
+
+. *What can I achieve with Boost.MP11?*
++
+With boost:mp11[], you can perform computations and logic at compile-time, thus reducing runtime overhead. For example, you can manipulate types, perform iterations, make decisions, and do other computations during the compilation phase.
+
+. *What is a `typelist` and how can I use it with Boost.MP11?*
++
+A `typelist` is a compile-time container of types. It's a fundamental concept in pass:[C++] template metaprogramming where operations are done at compile time rather than runtime, and types are manipulated in the same way that values are manipulated in regular programming.
++
+In the context of the boost:mp11[] library, a `typelist` is a template class that takes a variadic list of type parameters. Here's an example:
++
+[source,cpp]
+----
+#include <boost/mp11/list.hpp>
+
+using my_typelist = boost::mp11::mp_list<int, float, double>;
+----
++
+In this example, `my_typelist` is a `typelist` containing the types `int`, `float`, and `double`. Once you have a `typelist`, you can manipulate it using the metaprogramming functions provided by the library. For example:
++
+[source,cpp]
+----
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/algorithm.hpp>
+
+using my_typelist = boost::mp11::mp_list<int, float, double>;
+
+// Get the number of types in the list
+constexpr std::size_t size = boost::mp11::mp_size<my_typelist>::value;
+
+// Check if a type is in the list
+constexpr bool contains_double = boost::mp11::mp_contains<my_typelist, double>::value;
+
+// Add a type to the list
+using extended_typelist = boost::mp11::mp_push_back<my_typelist, char>;
+
+// Get the second type in the list
+using second_type = boost::mp11::mp_at_c<my_typelist, 1>;
+----
++
+In these examples, `mp_size` is used to get the number of types in the list, `mp_contains` checks if a type is in the list, `mp_push_back` adds a type to the list, and `mp_at_c` retrieves a type at a specific index in the list. All these operations are done at compile time.
+
+. *What are some limitations or challenges of metaprogramming with Boost.MP11?*
++
+Metaprogramming with boost:mp11[] can lead to complex and difficult-to-understand code, especially for programmers unfamiliar with the technique. Compile errors can be particularly cryptic due to the way templates are processed. Additionally, heavy use of templates can lead to longer compile times.
++
+Other challenges include lack of runtime flexibility, as decisions are made at compile time. And perhaps issues with portability can occur (say, between compilers) as metaprogramming pushes the boundaries of a computer language to its limits.
+
+NOTE: boost:mp11[] supersedes the earlier boost:mpl[] and boost:preprocessor[] libraries.
+
+=== Releases
+
+. *How do I download the latest libraries?*
++
+Go to https://www.boost.org/users/download/[Boost Downloads].
+
+. *What do the Boost version numbers mean?*
++
+The scheme is x.y.z, where x is incremented only for massive changes, such as a reorganization of many libraries, y is incremented whenever a new library is added, and z is incremented for maintenance releases. y and z are reset to 0 if the value to the left changes
+
+. *Is there a formal relationship between Boost.org and the pass:[C++] Standards Committee?*
++
+No, although there is a strong informal relationship in that many members of the committee participate in Boost, and the people who started Boost were all committee members.
+
+. *Will the Boost.org libraries become part of the next pass:[C++] Standard?*
++
+Some might, but that is up to the standards committee. Committee members who also participate in Boost will definitely be proposing at least some Boost libraries for standardization. Libraries which are "existing practice" are most likely to be accepted by the C++ committee for future standardization. Having a library accepted by Boost is one way to establish existing practice.
+
+. *Is the Boost web site a commercial business?*
++
+No. It is a non-profit.
+
+. *Why do Boost headers have a .hpp suffix rather than .h or none at all?*
++
+File extensions communicate the "type" of the file, both to humans and to computer programs. The '.h' extension is used for C header files, and therefore communicates the wrong thing about pass:[C++] header files. Using no extension communicates nothing and forces inspection of file contents to determine type. Using `.hpp` unambiguously identifies it as pass:[C++] header file, and works well in practice.
+
+. *How do I contribute a library?*
++
+Refer to the xref:contributor-guide:ROOT:index.adoc[]. Note that shareware libraries, commercial libraries, or libraries requiring restrictive licensing are all not acceptable. Your library must be provided free, with full source code, and have an acceptable license. There are other ways of contributing too, providing feedback, testing, submitting suggestions for new features and bug fixes, for example. There are no fees for submitting a library.
+
+
+=== Smart Pointers
+
+. *What different types of smart pointers are there?*
++
+The boost:smart_ptr[] library provides a set of smart pointers that helps in automatic and appropriate resource management. They are particularly useful for managing memory and provide a safer and more efficient way of handling dynamically allocated memory. The library provides the following types of smart pointers:
++
+[disc]
+* `boost::scoped_ptr`: A simple smart pointer for sole ownership of single objects that must be deleted. It's neither copyable nor movable. Deletion occurs automatically when the scoped_ptr goes out of scope.
+
+* `boost::scoped_array`: Similar to `scoped_ptr`, but for arrays instead of single objects. Deletion occurs automatically when the scoped_array goes out of scope.
+
+* `boost::shared_ptr`: A reference-counted smart pointer for single objects or arrays, which automatically deletes the object when the reference count reaches zero. Multiple `shared_ptr` can point to the same object, and the object is deleted when the last `shared_ptr` referencing it is destroyed.
+
+* `boost::shared_array`: Similar to `shared_ptr`, but for arrays instead of single objects.
+
+* `boost::weak_ptr`: A companion to `shared_ptr` that holds a non-owning ("weak") reference to an object that is managed by `shared_ptr`. It must be converted to `shared_ptr` in order to access the referenced object.
+
+* `boost::intrusive_ptr`: A smart pointer that uses intrusive reference counting. Intrusive reference counting relies on the object to maintain the reference count, rather than the smart pointer. This can provide performance benefits in certain situations, but it requires additional support from the referenced objects.
+
+* `boost::enable_shared_from_this`: Provides member function `shared_from_this`, which enables an object that's already managed by a `shared_ptr` to safely generate more `shared_ptr` instances that all share ownership of the same object.
+
+* `boost::unique_ptr`: A smart pointer that retains exclusive ownership of an object through a pointer. It's similar to `std::unique_ptr` in the pass:[C++] Standard Library.
+
+. *Can you give me a brief coding overview of how to use smart pointers efficiently?*
++
+There are several types of smart pointers with different characteristics and use cases, so use them appropriately according to your program's requirements. Here are some common examples:
+
++
+A `shared_ptr` is a reference-counting smart pointer, meaning it retains shared ownership of an object through a pointer. When the last `shared_ptr` to an object is destroyed, the pointed-to object is automatically deleted. For example:
++
+[source,cpp]
+----
+#include <boost/shared_ptr.hpp>
+
+void foo() {
+    boost::shared_ptr<int> sp(new int(10));
+    // Now 'sp' owns the 'int'.
+    // When 'sp' is destroyed, the 'int' will be deleted.
+}
+----
++
+Note that `shared_ptr` objects can be copied, meaning ownership of the memory can be shared among multiple pointers. The memory will be freed when the last remaining `shared_ptr` is destroyed. For example:
++
+[source,cpp]
+----
+#include <boost/shared_ptr.hpp>
+
+void foo() {
+    boost::shared_ptr<int> sp1(new int(10));
+    // Now 'sp1' owns the 'int'.
+    boost::shared_ptr<int> sp2 = sp1;
+    // Now 'sp1' and 'sp2' both own the same 'int'.
+    // The 'int' will not be deleted until both 'sp1' and 'sp2' are destroyed.
+}
+----
++
+A `weak_ptr` is a smart pointer that holds a non-owning ("weak") reference to an object managed by a `shared_ptr`. It must be converted to `shared_ptr` in order to access the object. For example:
++
+[source,cpp]
+----
+#include <boost/shared_ptr.hpp>
+#include <boost/weak_ptr.hpp>
+
+void foo() {
+    boost::shared_ptr<int> sp(new int(10));
+    boost::weak_ptr<int> wp = sp;
+    // 'wp' is a weak pointer to the 'int'.
+    // If 'sp' is destroyed, 'wp' will be able to detect it.
+}
+----
++
+A `unique_ptr` is a smart pointer that retains exclusive ownership of an object through a pointer. It's similar to `std::unique_ptr` in the pass:[C++] Standard Library. For example:
++
+[source,cpp]
+----
+#include <boost/interprocess/smart_ptr/unique_ptr.hpp>
+
+void foo() {
+    boost::movelib::unique_ptr<int> up(new int(10));
+    // Now 'up' owns the 'int'.
+    // When 'up' is destroyed, the 'int' will be deleted.
+}
+----
+
+
+=== Templates
+
+. *What are pass:[C++] templates?*
++
+pass:[C++] templates are a powerful feature of the language that allows for generic programming. They enable the creation of functions or classes that can operate on different data types without having to duplicate code.
+
+. *What are function templates in pass:[C++]?*
++
+Function templates are functions that can be used with any data type. You define them using the keyword template followed by the template parameters. Function templates allow you to create a single function that can operate on different data types.
+
+. *What is template specialization in pass:[C++]?*
++
+Template specialization is a feature of pass:[C++] templates that allows you to define a different implementation of a template for a specific type or set of types. It can be used with both class and function templates.
+
+. *What are the benefits and drawbacks of using templates in pass:[C++]?*
++
+The benefits of using templates include code reusability, type safety, and the ability to use generic programming paradigms. The drawbacks include potentially increased compile times, difficult-to-understand error messages, and complexities associated with template metaprogramming.
+
+. *How can I use templates to implement a generic sort function in pass:[C++]?*
++
+Here's a simple example of how you might use a function template to implement a generic sort function:
++
+[source,cpp]
+----
+template <typename T>
+void sort(T* array, int size) {
+    for(int i = 0; i < size; i++) {
+        for(int j = i + 1; j < size; j++) {
+            if(array[i] > array[j]) {
+                T temp = array[i];
+                array[i] = array[j];
+                array[j] = temp;
+            }
+        }
+    }
+}
+----
++
+This function can now be used to sort arrays of any type (that supports the `<` and `>` operators), not just a specific type.
+
+== See Also
+
+* xref:user-guide:ROOT:explore-the-content.adoc[]
+* xref:user-guide:ROOT:resources.adoc[]
+
+
+


### PR DESCRIPTION
Moving the user guide FAQ to the site-docs Help page. Doesn't seem like there should be conflicting sources, so will remove the FAQ from the User Guide in the next PR.

fix #79