### PR TITLE
Add common dependencies to best dev practices

### DIFF
--- a/contributor-guide/modules/ROOT/pages/best-practices.adoc
+++ b/contributor-guide/modules/ROOT/pages/best-practices.adoc
@@ -1,4 +1,39 @@
 = Best Practices
 :navtitle: Best Practices
 
-*Content under construction*
+This section contains guidance on how to reduce development time from concept through to publishing of a new library.
+
+== Common Dependencies
+
+Some libraries are published with the intended primary audience, or in some cases the sole audience, being developers of other libraries. These libraries are published to make some of the time consuming and awkward processes of Boost-compliance easier. It is good practice for a new library developer to read the introductions to each of these libraries, and ascertain if they might be of value to the library they are developing. The libraries in the following table are listed in the order of the number of other libraries that have included them as a primary dependency. The top eight listed below are a primary dependency of 50 or more other libraries.
+
+[cols="1,2,4",options="header",stripes=even,frame=none]
+|===
+| *Rank*  | *Library* | *Description* 
+| 1 | boost:config[] | Helps Boost library developers adapt to compiler idiosyncrasies
+| 2 | boost:core[] | A collection of simple core utilities with minimal dependencies
+| 3 | boost:type-traits[] | Templates for fundamental properties of types
+| 4 | boost:assert[] | Customizable assert macros
+| 5 | boost:static-assert[] | Static compile time assertions
+| 6 | boost:throwException[] | A common infrastructure for throwing exceptions from Boost libraries
+| 7 | boost:mpl[] | A general-purpose, high-level template metaprogramming framework of compile-time algorithms, sequences and metafunctions
+| 8 | boost:preprocessor[] | Preprocessor metaprogramming tools including repetition and recursion
+| 9 | boost:utility[] | A collection of general-purpose components for language support
+| 10 | boost:iterator[] | A system of concepts which extend the pass:[C++] standard iterator requirements and a framework of components for building iterators based on these extended concepts
+| 11 | boost:smart_ptr[] | Smart pointer class templates
+| 12= | boost:function[] | Function object wrappers for deferred calls or callbacks
+| 12= | boost:integer[] | Takes advantage of `<stdint.h>` types from the 1999 C standard without resorting to undefined behavior
+| 14 | boost:predef[] | Defines a set of compiler, architecture, operating system, library, and other version numbers
+| 15= | boost:range[] | An infrastructure for generic algorithms that builds on top of the new iterator concepts
+| 15= | boost:move[] | Portable move semantics for pass:[C++03] and pass:[C++11] compilers
+| 15= | boost:optional[] | A value-semantic, type-safe wrapper for representing 'optional' (or 'nullable') objects of a given type
+| 18 | boost:container-hash[] | An STL-compatible hash function object that can be extended to hash user defined types
+| 19= | boost:array[] | STL compliant container wrapper for arrays of constant size
+| 19= | boost:bind[] | Bind any argument to a specific value or route input arguments into arbitrary positions
+| 19= | boost:concept-check[] | Tools for generic programming
+| 22 | boost:typeof[] | Operator emulation
+|===
+
+== See Also
+
+* xref:version-control.adoc[]

--- a/contributor-guide/modules/ROOT/pages/best-practices.adoc
+++ b/contributor-guide/modules/ROOT/pages/best-practices.adoc
@@ -3,35 +3,19 @@
 
 This section contains guidance on how to reduce development time from concept through to publishing of a new library.
 
-== Common Dependencies
+== Beneficial Dependencies
 
-Some libraries are published with the intended primary audience, or in some cases the sole audience, being developers of other libraries. These libraries are published to make some of the time consuming and awkward processes of Boost-compliance easier. It is good practice for a new library developer to read the introductions to each of these libraries, and ascertain if they might be of value to the library they are developing. The libraries in the following table are listed in the order of the number of other libraries that have included them as a primary dependency. The top eight listed below are a primary dependency of 50 or more other libraries.
+Some libraries are published with the intended primary audience, or in some cases the sole audience, being developers of other libraries. These libraries are published to make some of the time consuming and awkward processes of Boost-compliance easier. It is good practice for a new library developer to read the introductions to each of these libraries, and ascertain if they might be of value to the library they are developing. 
 
-[cols="1,2,4",options="header",stripes=even,frame=none]
+[cols="1,4",options="header",stripes=even,frame=none]
 |===
-| *Rank*  | *Library* | *Description* 
-| 1 | boost:config[] | Helps Boost library developers adapt to compiler idiosyncrasies
-| 2 | boost:core[] | A collection of simple core utilities with minimal dependencies
-| 3 | boost:type-traits[] | Templates for fundamental properties of types
-| 4 | boost:assert[] | Customizable assert macros
-| 5 | boost:static-assert[] | Static compile time assertions
-| 6 | boost:throwException[] | A common infrastructure for throwing exceptions from Boost libraries
-| 7 | boost:mpl[] | A general-purpose, high-level template metaprogramming framework of compile-time algorithms, sequences and metafunctions
-| 8 | boost:preprocessor[] | Preprocessor metaprogramming tools including repetition and recursion
-| 9 | boost:utility[] | A collection of general-purpose components for language support
-| 10 | boost:iterator[] | A system of concepts which extend the pass:[C++] standard iterator requirements and a framework of components for building iterators based on these extended concepts
-| 11 | boost:smart_ptr[] | Smart pointer class templates
-| 12= | boost:function[] | Function object wrappers for deferred calls or callbacks
-| 12= | boost:integer[] | Takes advantage of `<stdint.h>` types from the 1999 C standard without resorting to undefined behavior
-| 14 | boost:predef[] | Defines a set of compiler, architecture, operating system, library, and other version numbers
-| 15= | boost:range[] | An infrastructure for generic algorithms that builds on top of the new iterator concepts
-| 15= | boost:move[] | Portable move semantics for pass:[C++03] and pass:[C++11] compilers
-| 15= | boost:optional[] | A value-semantic, type-safe wrapper for representing 'optional' (or 'nullable') objects of a given type
-| 18 | boost:container-hash[] | An STL-compatible hash function object that can be extended to hash user defined types
-| 19= | boost:array[] | STL compliant container wrapper for arrays of constant size
-| 19= | boost:bind[] | Bind any argument to a specific value or route input arguments into arbitrary positions
-| 19= | boost:concept-check[] | Tools for generic programming
-| 22 | boost:typeof[] | Operator emulation
+| *Library* | *Description* 
+| boost:config[] | Helps Boost library developers adapt to compiler idiosyncrasies. The range of macros can be extended, if required, with boost:predef[].
+| boost:core[] | A collection of simple core utilities with minimal dependencies. The range of utilities can be extended, if required, with boost:utility[]
+| boost:assert[] | Customizable assert macros.
+| boost:static-assert[] | Static compile time assertions.
+| boost:throwException[] | A common infrastructure for throwing exceptions from Boost libraries.
+| boost:mp11[] | Provides a template metaprogramming framework, useful if metaprogramming is a feature of your new library.
 |===
 
 == See Also


### PR DESCRIPTION
Added a table of the 20 libraries most commonly depended on by other libraries, to the Best Practices section of the Contributor Guide.