### PR TITLE
Remove demo from README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,10 +7,6 @@
 
 This tool renders the documentation for Boost modules whose documentation use asciidoc.
 
-== Demo
-
-- https://antora.cppalliance.org/develop/libs/mp11/
-
 == Installing Antora
 
 CAUTION: The workflow may change in the future.


### PR DESCRIPTION
All libraries have been removed as components since this has been integrated into the official Boost release workflow. Thus, the old demo links are broken.