### PR TITLE
Add Modular Boost section of User FAQ

### DIFF
--- a/user-guide/modules/ROOT/pages/faq.adoc
+++ b/user-guide/modules/ROOT/pages/faq.adoc
@@ -19,7 +19,6 @@ Yes, Boost libraries are designed to work with modern pass:[C++] standards inclu
 +
 Boost libraries are generally compatible with most Linux distributions, provided that the distribution has an up-to-date pass:[C++] compiler. This includes:
 +
-[circle]
 * Ubuntu
 * Fedora
 * Debian
@@ -92,15 +91,15 @@ Smart pointers are a feature of pass:[C++] that Boost provides in its boost:smar
 
 . *Does Boost provide a testing framework?*
 +
-Yes, boost:test[] is the unit testing framework provided by Boost. It includes tools for creating test cases, test suites, and for handling expected and unexpected exceptions.
+Yes, boost:test[] is the unit testing framework provided by Boost. It includes tools for creating test cases, test suites, and for handling expected and unexpected exceptions. Refer to xref:testing-debugging.adoc[].
 
 . *What is Boost.Asio?*
 +
 boost:asio[] is a library that provides support for asynchronous input/output (I/O), a programming concept that allows operations to be executed without blocking the execution of the rest of the program.
 
-. *What is Boost.MPL?*
+. *What is Boost.MP11?*
 +
-boost:mpl[] (MetaProgramming Library) is a Boost library designed to bring powerful metaprogramming capabilities to pass:[C++] programs. It includes a variety of templates that can be used to perform compile-time computations and manipulations.
+boost:mp11[] (MetaProgramming Library for pass:[C++]11) is a Boost library designed to bring powerful metaprogramming capabilities to pass:[C++] programs. It includes a variety of templates that can be used to perform compile-time computations and manipulations. Refer to <<Metaprogramming>>.
 
 . *Does Boost provide a library for threading?*
 +
@@ -115,7 +114,6 @@ boost:spirit[] is a library for building recursive-descent parsers directly in p
 Boost libraries offer a wide range of algorithmic and data structure support. Here are five libraries that you might find interesting:
 
 +
-[circle]
 * boost:graph[]: This library provides a way to represent and manipulate graphs. It includes algorithms for breadth-first search, depth-first search, Dijkstra's shortest paths, Kruskal's minimum spanning tree, and much more.
 
 * boost:geometry[]: This library includes algorithms and data structures for working with geometric objects. It includes support for spatial indexing, geometric algorithms (like area calculation, distance calculation, intersections, etc.), and data structures to represent points, polygons, and other geometric objects.
@@ -128,24 +126,7 @@ Boost libraries offer a wide range of algorithmic and data structure support. He
 
 . *I am tasked with building a real-time simulation of vehicles in pass:[C++]. What Boost libraries might give me the performance I need for real-time work, and support a simulation?*
 +
-Creating a real-time simulation of vehicles involves various aspects, including physical modeling, concurrent programming for real-time response, data storage and manipulation, networking for multi-vehicle simulation, and perhaps even a graphic interface. Here are some libraries that may be helpful:
-+
-[circle]
-* boost:chrono[]: Timing is critical in real-time applications. This library can help you measure time intervals, which could be useful for controlling the timing of your simulation.
-
-* boost:geometry[]: For spatial computations and geometric algorithms, which you will likely need for modeling the physical behavior and interactions of your vehicles.
-
-* boost:units[]: This library can help with calculations involving units of measurement. It provides classes and functions that can enforce the correct usage of units and conversions between them, which could be helpful in a physical simulation.
- 
-* boost:graph[]: In case you need to represent roads or pathways as a graph, this library provides a flexible and powerful way to represent and manipulate graphs. It also includes a number of graph algorithms.
-
-* boost:thread[] or boost:asio[]: To achieve real-time performance, you might need to make use of multi-threading or asynchronous input/output. boost:thread[] provides classes and functions for multi-threading, synchronization, and inter-thread communication. boost:asio[] is a cross-platform library for asynchronous programming and can handle a lot of networking tasks as well.
-
-* boost:interprocess[]: If you need to share data between different processes in real-time, this library can be useful. It supports shared memory, memory-mapped files, semaphores, and more.
-
-* boost:mpi[] or boost:asio[]: For distributed simulations that run across multiple systems, you might need a library for network communication. boost:mpi[] provides a pass:[C++] interface for the Message Passing Interface (MPI) standard for distributed computing. boost:asio[] can also handle networking tasks and it is a bit lower-level.
-
-* boost:serialization[]: To save the state of the simulation or to communicate complex data structures over a network, you might find this library helpful.
+Refer to xref:task-simulation.adoc[].
 
 == Licensing 
 
@@ -159,21 +140,58 @@ The Boost libraries are licensed under the Boost Software License, a permissive 
 +
 Metaprogramming is a technique of programming that involves generating and manipulating programs. In the context of Boost and pass:[C++], metaprogramming often refers to template metaprogramming, which uses templates to perform computations at compile-time.
 
-. *What is Boost.MPL?*
+. *What is Boost.MP11?*
 +
-boost:mpl[] is a Boost library designed for metaprogramming. It provides a set of templates and types for compile-time computations and manipulations, effectively extending the pass:[C++] template mechanism.
+boost:mp11[] is a Boost library designed for metaprogramming. It provides a set of templates and types for compile-time computations and manipulations, effectively extending the pass:[C++] template mechanism.
 
-. *What can I achieve with Boost.MPL?*
+. *What can I achieve with Boost.MP11?*
 +
-With boost:mpl[], you can perform computations and logic at compile-time, thus reducing runtime overhead. For example, you can manipulate types, perform iterations, make decisions, and do other computations during the compilation phase.
+With boost:mp11[], you can perform computations and logic at compile-time, thus reducing runtime overhead. For example, you can manipulate types, perform iterations, make decisions, and do other computations during the compilation phase.
 
-. *What is a `typelist` and how can I use it with Boost.MPL?*
+. *What is a `typelist` and how can I use it with Boost.MP11?*
 +
-A `typelist` is a compile-time list of types. In boost:mpl[], you can create a `typelist` using `boost::mpl::vector<>`, `boost::mpl::list<>`, or other sequence types. Typelists can be used for various compile-time operations such as counting the number of types, transforming types, or selecting a type based on a condition.
+A `typelist` is a compile-time container of types. It's a fundamental concept in pass:[C++] template metaprogramming where operations are done at compile time rather than runtime, and types are manipulated in the same way that values are manipulated in regular programming.
++
+In the context of the boost:mp11[] library, a `typelist` is a template class that takes a variadic list of type parameters. Here's an example:
++
+[source,cpp]
+----
+#include <boost/mp11/list.hpp>
 
-. *What are some limitations or challenges of metaprogramming with Boost.MPL?*
+using my_typelist = boost::mp11::mp_list<int, float, double>;
+----
 +
-Metaprogramming with boost:mpl[] can lead to complex and difficult-to-understand code, especially for programmers unfamiliar with the technique. Compile errors can be particularly cryptic due to the way templates are processed. Additionally, heavy use of templates can lead to longer compile times.
+In this example, `my_typelist` is a `typelist` containing the types `int`, `float`, and `double`. Once you have a `typelist`, you can manipulate it using the metaprogramming functions provided by the library. For example:
++
+[source,cpp]
+----
+#include <boost/mp11/list.hpp>
+#include <boost/mp11/algorithm.hpp>
+
+using my_typelist = boost::mp11::mp_list<int, float, double>;
+
+// Get the number of types in the list
+constexpr std::size_t size = boost::mp11::mp_size<my_typelist>::value;
+
+// Check if a type is in the list
+constexpr bool contains_double = boost::mp11::mp_contains<my_typelist, double>::value;
+
+// Add a type to the list
+using extended_typelist = boost::mp11::mp_push_back<my_typelist, char>;
+
+// Get the second type in the list
+using second_type = boost::mp11::mp_at_c<my_typelist, 1>;
+----
++
+In these examples, `mp_size` is used to get the number of types in the list, `mp_contains` checks if a type is in the list, `mp_push_back` adds a type to the list, and `mp_at_c` retrieves a type at a specific index in the list. All these operations are done at compile time.
+
+. *What are some limitations or challenges of metaprogramming with Boost.MP11?*
++
+Metaprogramming with boost:mp11[] can lead to complex and difficult-to-understand code, especially for programmers unfamiliar with the technique. Compile errors can be particularly cryptic due to the way templates are processed. Additionally, heavy use of templates can lead to longer compile times.
++
+Other challenges include lack of runtime flexibility, as decisions are made at compile time. And perhaps issues with portability can occur (say, between compilers) as metaprogramming pushes the boundaries of a computer language to its limits.
+
+NOTE: boost:mp11[] supersedes the earlier boost:mpl[] and boost:preprocessor[] libraries.
 
 == Modular Boost
 
@@ -211,6 +229,37 @@ Correct - backwards-compatibility should be maintained.
 . *When will Modular Boost be available to users?*
 +
 An exact timeline requires issues to be resolved, though later in 2024 is the current plan-of-record.
+
+== Releases
+
+. *How do I download the latest libraries?*
++
+Go to https://www.boost.org/users/download/[Boost Downloads].
+
+. *What do the Boost version numbers mean?*
++
+The scheme is x.y.z, where x is incremented only for massive changes, such as a reorganization of many libraries, y is incremented whenever a new library is added, and z is incremented for maintenance releases. y and z are reset to 0 if the value to the left changes
+
+. *Is there a formal relationship between Boost.org and the pass:[C++] Standards Committee?*
++
+No, although there is a strong informal relationship in that many members of the committee participate in Boost, and the people who started Boost were all committee members.
+
+. *Will the Boost.org libraries become part of the next pass:[C++] Standard?*
++
+Some might, but that is up to the standards committee. Committee members who also participate in Boost will definitely be proposing at least some Boost libraries for standardization. Libraries which are "existing practice" are most likely to be accepted by the C++ committee for future standardization. Having a library accepted by Boost is one way to establish existing practice.
+
+. *Is the Boost web site a commercial business?*
++
+No. It is a non-profit.
+
+. *Why do Boost headers have a .hpp suffix rather than .h or none at all?*
++
+File extensions communicate the "type" of the file, both to humans and to computer programs. The '.h' extension is used for C header files, and therefore communicates the wrong thing about pass:[C++] header files. Using no extension communicates nothing and forces inspection of file contents to determine type. Using `.hpp` unambiguously identifies it as pass:[C++] header file, and works well in practice.
+
+. *How do I contribute a library?*
++
+Refer to the xref:contributor-guide:ROOT:index.adoc[]. Note that shareware libraries, commercial libraries, or libraries requiring restrictive licensing are all not acceptable. Your library must be provided free, with full source code, and have an acceptable license. There are other ways of contributing too, providing feedback, testing, submitting suggestions for new features and bug fixes, for example. There are no fees for submitting a library.
+
 
 == Smart Pointers
 
@@ -341,3 +390,4 @@ This function can now be used to sort arrays of any type (that supports the `<` 
 
 * xref:explore-the-content.adoc[]
 * xref:resources.adoc[]
+

--- a/user-guide/modules/ROOT/pages/faq.adoc
+++ b/user-guide/modules/ROOT/pages/faq.adoc
@@ -19,6 +19,7 @@ Yes, Boost libraries are designed to work with modern pass:[C++] standards inclu
 +
 Boost libraries are generally compatible with most Linux distributions, provided that the distribution has an up-to-date pass:[C++] compiler. This includes:
 +
+[circle]
 * Ubuntu
 * Fedora
 * Debian
@@ -91,15 +92,15 @@ Smart pointers are a feature of pass:[C++] that Boost provides in its boost:smar
 
 . *Does Boost provide a testing framework?*
 +
-Yes, boost:test[] is the unit testing framework provided by Boost. It includes tools for creating test cases, test suites, and for handling expected and unexpected exceptions. Refer to xref:testing-debugging.adoc[].
+Yes, boost:test[] is the unit testing framework provided by Boost. It includes tools for creating test cases, test suites, and for handling expected and unexpected exceptions.
 
 . *What is Boost.Asio?*
 +
 boost:asio[] is a library that provides support for asynchronous input/output (I/O), a programming concept that allows operations to be executed without blocking the execution of the rest of the program.
 
-. *What is Boost.MP11?*
+. *What is Boost.MPL?*
 +
-boost:mp11[] (MetaProgramming Library for pass:[C++]11) is a Boost library designed to bring powerful metaprogramming capabilities to pass:[C++] programs. It includes a variety of templates that can be used to perform compile-time computations and manipulations. Refer to <<Metaprogramming>>.
+boost:mpl[] (MetaProgramming Library) is a Boost library designed to bring powerful metaprogramming capabilities to pass:[C++] programs. It includes a variety of templates that can be used to perform compile-time computations and manipulations.
 
 . *Does Boost provide a library for threading?*
 +
@@ -114,6 +115,7 @@ boost:spirit[] is a library for building recursive-descent parsers directly in p
 Boost libraries offer a wide range of algorithmic and data structure support. Here are five libraries that you might find interesting:
 
 +
+[circle]
 * boost:graph[]: This library provides a way to represent and manipulate graphs. It includes algorithms for breadth-first search, depth-first search, Dijkstra's shortest paths, Kruskal's minimum spanning tree, and much more.
 
 * boost:geometry[]: This library includes algorithms and data structures for working with geometric objects. It includes support for spatial indexing, geometric algorithms (like area calculation, distance calculation, intersections, etc.), and data structures to represent points, polygons, and other geometric objects.
@@ -126,7 +128,24 @@ Boost libraries offer a wide range of algorithmic and data structure support. He
 
 . *I am tasked with building a real-time simulation of vehicles in pass:[C++]. What Boost libraries might give me the performance I need for real-time work, and support a simulation?*
 +
-Refer to xref:task-simulation.adoc[].
+Creating a real-time simulation of vehicles involves various aspects, including physical modeling, concurrent programming for real-time response, data storage and manipulation, networking for multi-vehicle simulation, and perhaps even a graphic interface. Here are some libraries that may be helpful:
++
+[circle]
+* boost:chrono[]: Timing is critical in real-time applications. This library can help you measure time intervals, which could be useful for controlling the timing of your simulation.
+
+* boost:geometry[]: For spatial computations and geometric algorithms, which you will likely need for modeling the physical behavior and interactions of your vehicles.
+
+* boost:units[]: This library can help with calculations involving units of measurement. It provides classes and functions that can enforce the correct usage of units and conversions between them, which could be helpful in a physical simulation.
+ 
+* boost:graph[]: In case you need to represent roads or pathways as a graph, this library provides a flexible and powerful way to represent and manipulate graphs. It also includes a number of graph algorithms.
+
+* boost:thread[] or boost:asio[]: To achieve real-time performance, you might need to make use of multi-threading or asynchronous input/output. boost:thread[] provides classes and functions for multi-threading, synchronization, and inter-thread communication. boost:asio[] is a cross-platform library for asynchronous programming and can handle a lot of networking tasks as well.
+
+* boost:interprocess[]: If you need to share data between different processes in real-time, this library can be useful. It supports shared memory, memory-mapped files, semaphores, and more.
+
+* boost:mpi[] or boost:asio[]: For distributed simulations that run across multiple systems, you might need a library for network communication. boost:mpi[] provides a pass:[C++] interface for the Message Passing Interface (MPI) standard for distributed computing. boost:asio[] can also handle networking tasks and it is a bit lower-level.
+
+* boost:serialization[]: To save the state of the simulation or to communicate complex data structures over a network, you might find this library helpful.
 
 == Licensing 
 
@@ -140,89 +159,58 @@ The Boost libraries are licensed under the Boost Software License, a permissive 
 +
 Metaprogramming is a technique of programming that involves generating and manipulating programs. In the context of Boost and pass:[C++], metaprogramming often refers to template metaprogramming, which uses templates to perform computations at compile-time.
 
-. *What is Boost.MP11?*
+. *What is Boost.MPL?*
 +
-boost:mp11[] is a Boost library designed for metaprogramming. It provides a set of templates and types for compile-time computations and manipulations, effectively extending the pass:[C++] template mechanism.
+boost:mpl[] is a Boost library designed for metaprogramming. It provides a set of templates and types for compile-time computations and manipulations, effectively extending the pass:[C++] template mechanism.
 
-. *What can I achieve with Boost.MP11?*
+. *What can I achieve with Boost.MPL?*
 +
-With boost:mp11[], you can perform computations and logic at compile-time, thus reducing runtime overhead. For example, you can manipulate types, perform iterations, make decisions, and do other computations during the compilation phase.
+With boost:mpl[], you can perform computations and logic at compile-time, thus reducing runtime overhead. For example, you can manipulate types, perform iterations, make decisions, and do other computations during the compilation phase.
 
-. *What is a `typelist` and how can I use it with Boost.MP11?*
+. *What is a `typelist` and how can I use it with Boost.MPL?*
 +
-A `typelist` is a compile-time container of types. It's a fundamental concept in pass:[C++] template metaprogramming where operations are done at compile time rather than runtime, and types are manipulated in the same way that values are manipulated in regular programming.
+A `typelist` is a compile-time list of types. In boost:mpl[], you can create a `typelist` using `boost::mpl::vector<>`, `boost::mpl::list<>`, or other sequence types. Typelists can be used for various compile-time operations such as counting the number of types, transforming types, or selecting a type based on a condition.
+
+. *What are some limitations or challenges of metaprogramming with Boost.MPL?*
 +
-In the context of the boost:mp11[] library, a `typelist` is a template class that takes a variadic list of type parameters. Here's an example:
+Metaprogramming with boost:mpl[] can lead to complex and difficult-to-understand code, especially for programmers unfamiliar with the technique. Compile errors can be particularly cryptic due to the way templates are processed. Additionally, heavy use of templates can lead to longer compile times.
+
+== Modular Boost
+
+. *What is meant by "Modular Boost"?*
 +
-[source,cpp]
-----
-#include <boost/mp11/list.hpp>
-
-using my_typelist = boost::mp11::mp_list<int, float, double>;
-----
+Technically, Modular Boost consists of the Boost super-project and separate projects for each individual library in Boost. In terms of Git, the Boost super-project treats the individual libraries as submodules. Currently (early 2024) when the Boost libraries are downloaded and installed, the build organization does _not_ match the modular arrangement of the Git super-project. This is largely a legacy issue, and there are advantages to the build layout matching the super-project layout. This concept, and the effort behind it, is known as "Modular Boost".
 +
-In this example, `my_typelist` is a `typelist` containing the types `int`, `float`, and `double`. Once you have a `typelist`, you can manipulate it using the metaprogramming functions provided by the library. For example:
+Refer to the xref:contributor-guide:ROOT:superproject/overview.adoc[] topic (in the xref:contributor-guide:ROOT:index.adoc[]) for a full description of the super-project.
+
+. *Will a Modular Boost affect the thrice-yearly Boost Release?*
 +
-[source,cpp]
-----
-#include <boost/mp11/list.hpp>
-#include <boost/mp11/algorithm.hpp>
+No. The collection of libraries is still a single release, and there are no plans to change the release cadence.
 
-using my_typelist = boost::mp11::mp_list<int, float, double>;
-
-// Get the number of types in the list
-constexpr std::size_t size = boost::mp11::mp_size<my_typelist>::value;
-
-// Check if a type is in the list
-constexpr bool contains_double = boost::mp11::mp_contains<my_typelist, double>::value;
-
-// Add a type to the list
-using extended_typelist = boost::mp11::mp_push_back<my_typelist, char>;
-
-// Get the second type in the list
-using second_type = boost::mp11::mp_at_c<my_typelist, 1>;
-----
+. *Will this require that the current Boost source structure is changed?*
 +
-In these examples, `mp_size` is used to get the number of types in the list, `mp_contains` checks if a type is in the list, `mp_push_back` adds a type to the list, and `mp_at_c` retrieves a type at a specific index in the list. All these operations are done at compile time.
+Yes. Unfortunately there is one restriction that adhering to a modular Boost requires - there can be no sub-libraries. That is, we can't support having libraries in the `root/libs/<group name>/<library>` format. All libraries must be single libraries under the `root/libs` directory. There's only a handful of libraries that currently do not conform to this already (notably the `root/libs/numeric/<name>` group of libraries).
 
-. *What are some limitations or challenges of metaprogramming with Boost.MP11?*
+. *Why do we want a Modular Boost?*
 +
-Metaprogramming with boost:mp11[] can lead to complex and difficult-to-understand code, especially for programmers unfamiliar with the technique. Compile errors can be particularly cryptic due to the way templates are processed. Additionally, heavy use of templates can lead to longer compile times.
+It's easier on everyone if we adopt a flat hierarchy. The user will experience a consistent process no matter which libraries they want to use. Similarly for contributors, the creation process will be consistent. Also, tools can be written that can parse and analyze libraries without an awkward range of exceptions. This includes tools written by Boost contributors. For example, the tools that are used to determine library dependencies. And any tool that a user might want to write for their own, or shared, use.
+
 +
-Other challenges include lack of runtime flexibility, as decisions are made at compile time. And perhaps issues with portability can occur (say, between compilers) as metaprogramming pushes the boundaries of a computer language to its limits.
-
-NOTE: boost:mp11[] supersedes the earlier boost:mpl[] and boost:preprocessor[] libraries.
-
-== Releases
-
-. *How do I download the latest libraries?*
+Other advantages of a modular format include:
 +
-Go to https://www.boost.org/users/download/[Boost Downloads].
-
-. *What do the Boost version numbers mean?*
+* Users of Boost can now choose to include only the specific modules they need for their project, rather than downloading and building the entire Boost framework. This can significantly reduce the size of the codebase and dependencies in a project, leading to faster compilation times and reduced resource usage.
 +
-The scheme is x.y.z, where x is incremented only for massive changes, such as a reorganization of many libraries, y is incremented whenever a new library is added, and z is incremented for maintenance releases. y and z are reset to 0 if the value to the left changes
-
-. *Is there a formal relationship between Boost.org and the pass:[C++] Standards Committee?*
+* Individual modules can be updated and released on their own schedule, independent of the rest of the libraries. This allows for quicker updates and bug fixes to individual libraries without waiting for a full release.
 +
-No, although there is a strong informal relationship in that many members of the committee participate in Boost, and the people who started Boost were all committee members.
+* The structure aligns well with package managers like Conan, vcpkg, or Bazel, making it easier to manage Boost libraries within larger projects. Users can specify exactly which Boost libraries they need, and the package manager handles the inclusion and versioning.
 
-. *Will the Boost.org libraries become part of the next pass:[C++] Standard?*
+. *Will the proposed changes be backwards-compatible from the user's perspective. In particular, the public header inclusion paths will still be <boost/numeric/<name>.hpp> rather than, say, <boost/numeric-conversion/<name>.hpp>, correct?*
 +
-Some might, but that is up to the standards committee. Committee members who also participate in Boost will definitely be proposing at least some Boost libraries for standardization. Libraries which are "existing practice" are most likely to be accepted by the C++ committee for future standardization. Having a library accepted by Boost is one way to establish existing practice.
+Correct - backwards-compatibility should be maintained.
 
-. *Is the Boost web site a commercial business?*
+. *When will Modular Boost be available to users?*
 +
-No. It is a non-profit.
-
-. *Why do Boost headers have a .hpp suffix rather than .h or none at all?*
-+
-File extensions communicate the "type" of the file, both to humans and to computer programs. The '.h' extension is used for C header files, and therefore communicates the wrong thing about pass:[C++] header files. Using no extension communicates nothing and forces inspection of file contents to determine type. Using `.hpp` unambiguously identifies it as pass:[C++] header file, and works well in practice.
-
-. *How do I contribute a library?*
-+
-Refer to the xref:contributor-guide:ROOT:index.adoc[]. Note that shareware libraries, commercial libraries, or libraries requiring restrictive licensing are all not acceptable. Your library must be provided free, with full source code, and have an acceptable license. There are other ways of contributing too, providing feedback, testing, submitting suggestions for new features and bug fixes, for example. There are no fees for submitting a library.
-
+An exact timeline requires issues to be resolved, though later in 2024 is the current plan-of-record.
 
 == Smart Pointers
 
@@ -353,4 +341,3 @@ This function can now be used to sort arrays of any type (that supports the `<` 
 
 * xref:explore-the-content.adoc[]
 * xref:resources.adoc[]
-

--- a/user-guide/modules/ROOT/pages/resources.adoc
+++ b/user-guide/modules/ROOT/pages/resources.adoc
@@ -39,4 +39,3 @@ For more specific technical questions, Stack Overflow has many questions and ans
 
 * xref:explore-the-content.adoc[]
 * xref:faq.adoc[]
-


### PR DESCRIPTION
Parsed the email exchanges and added some questions and answers to the User Guide FAQ - leaving questions and answers more suited for the Contributor Guide aside for the moment. @grafikrobot any feedback?